### PR TITLE
Add SPECENERGY opcodes

### DIFF
--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -288,6 +288,7 @@ export default class Player extends PathingEntity {
     run: number = 0;
     tempRun: number = 0;
     runenergy: number = 10000;
+    specEnergy: number = 1000;
     lastRunEnergy: number = -1;
     runweight: number = 0;
     playtime: number = 0;

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -200,6 +200,8 @@ export const enum ScriptOpcode {
     SETSKINCOLOUR,
     P_ANIMPROTECT,
     RUNENERGY,
+    SPECENERGY,
+    SPECENERGY_SET,
     WEIGHT,
     LAST_COORD,
     SESSION_LOG, // custom
@@ -645,6 +647,8 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['SETSKINCOLOUR', ScriptOpcode.SETSKINCOLOUR],
     ['P_ANIMPROTECT', ScriptOpcode.P_ANIMPROTECT],
     ['RUNENERGY', ScriptOpcode.RUNENERGY],
+    ['SPECENERGY', ScriptOpcode.SPECENERGY],
+    ['SPECENERGY_SET', ScriptOpcode.SPECENERGY_SET],
     ['WEIGHT', ScriptOpcode.WEIGHT],
     ['LAST_COORD', ScriptOpcode.LAST_COORD],
     ['SESSION_LOG', ScriptOpcode.SESSION_LOG],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -508,6 +508,13 @@ const ScriptOpcodePointers: {
         require: ['active_player'],
         require2: ['active_player2']
     },
+    [ScriptOpcode.SPECENERGY]: {
+        require: ['active_player'],
+        require2: ['active_player2']
+    },
+    [ScriptOpcode.SPECENERGY_SET]: {
+        require: ['active_player']
+    },
     [ScriptOpcode.WEIGHT]: {
         require: ['p_active_player'],
         require2: ['p_active_player2']

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -1128,6 +1128,15 @@ const PlayerOps: CommandHandlers = {
         state.pushInt(player.runenergy);
     }),
 
+    [ScriptOpcode.SPECENERGY]: checkedHandler(ActivePlayer, state => {
+        const player = state.activePlayer;
+        state.pushInt(player.specEnergy);
+    }),
+
+    [ScriptOpcode.SPECENERGY_SET]: checkedHandler(ActivePlayer, state => {
+        state.activePlayer.specEnergy = check(state.popInt(), NumberNotNull);
+    }),
+
     [ScriptOpcode.WEIGHT]: checkedHandler(ProtectedActivePlayer, state => {
         state.pushInt(state.activePlayer.runweight);
     }),


### PR DESCRIPTION
## Summary
- add `SPECENERGY` and `SPECENERGY_SET` opcodes
- expose `specEnergy` property on `Player`
- implement handlers and pointer metadata for spec energy

## Testing
- `npm test` *(fails: vitest not found)*