### PR TITLE
Add placeholder special attack support

### DIFF
--- a/data/src/scripts/skill_combat/scripts/player/special_attack.rs2
+++ b/data/src/scripts/skill_combat/scripts/player/special_attack.rs2
@@ -1,0 +1,10 @@
+[proc,special_attack](player_uid $target, int $damage, seq $anim, spotanim $gfx, int $cost)
+if (%spec_energy < $cost) {
+    mes("You don't have enough special energy.");
+    return;
+}
+%spec_energy = sub(%spec_energy, $cost);
+anim($anim, 0);
+spotanim_pl($gfx, 0, 0);
+damage($target, 1, $damage);
+

--- a/src/cache/config/Component.ts
+++ b/src/cache/config/Component.ts
@@ -19,6 +19,7 @@ export default class Component {
     static TOGGLE_BUTTON: number = 4;
     static SELECT_BUTTON: number = 5;
     static PAUSE_BUTTON: number = 6;
+    static SPEC_ATTACK_BUTTON: number = -1; // TODO: replace with real id
 
     private static componentNames: Map<string, number> = new Map();
     private static components: Component[] = [];

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -288,6 +288,7 @@ export default class Player extends PathingEntity {
     run: number = 0;
     tempRun: number = 0;
     runenergy: number = 10000;
+    specEnergy: number = 1000;
     lastRunEnergy: number = -1;
     runweight: number = 0;
     playtime: number = 0;

--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -206,6 +206,8 @@ export const enum ScriptOpcode {
     WEALTH_LOG, // custom
     WEALTH_EVENT, // custom
     P_RUN, // todo: real command name?
+    SPECENERGY,
+    SET_SPECENERGY,
 
     // Npc ops (2500-2999)
     NPC_ADD = 2500, // official
@@ -651,6 +653,8 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['WEALTH_LOG', ScriptOpcode.WEALTH_LOG],
     ['WEALTH_EVENT', ScriptOpcode.WEALTH_EVENT],
     ['P_RUN', ScriptOpcode.P_RUN],
+    ['SPECENERGY', ScriptOpcode.SPECENERGY],
+    ['SET_SPECENERGY', ScriptOpcode.SET_SPECENERGY],
     ['NPC_ADD', ScriptOpcode.NPC_ADD],
     ['NPC_ANIM', ScriptOpcode.NPC_ANIM],
     ['NPC_BASESTAT', ScriptOpcode.NPC_BASESTAT],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -520,6 +520,14 @@ const ScriptOpcodePointers: {
         require: ['p_active_player'],
         require2: ['p_active_player2']
     },
+    [ScriptOpcode.SPECENERGY]: {
+        require: ['active_player'],
+        require2: ['active_player2']
+    },
+    [ScriptOpcode.SET_SPECENERGY]: {
+        require: ['p_active_player'],
+        require2: ['p_active_player2']
+    },
 
     // Npc ops
     [ScriptOpcode.NPC_ADD]: {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -1128,6 +1128,15 @@ const PlayerOps: CommandHandlers = {
         state.pushInt(player.runenergy);
     }),
 
+    [ScriptOpcode.SPECENERGY]: checkedHandler(ActivePlayer, state => {
+        const player = state.activePlayer;
+        state.pushInt(player.specEnergy);
+    }),
+
+    [ScriptOpcode.SET_SPECENERGY]: checkedHandler(ProtectedActivePlayer, state => {
+        state.activePlayer.specEnergy = check(state.popInt(), NumberNotNull);
+    }),
+
     [ScriptOpcode.WEIGHT]: checkedHandler(ProtectedActivePlayer, state => {
         state.pushInt(state.activePlayer.runweight);
     }),

--- a/src/network/game/client/handler/IfButtonHandler.ts
+++ b/src/network/game/client/handler/IfButtonHandler.ts
@@ -18,6 +18,14 @@ export default class IfButtonHandler extends MessageHandler<IfButton> {
             return false;
         }
 
+        if (comId === Component.SPEC_ATTACK_BUTTON) {
+            const spec = ScriptProvider.getByName('special_attack');
+            if (spec) {
+                player.executeScript(ScriptRunner.init(spec, player), true);
+            }
+            return true;
+        }
+
         player.lastCom = comId;
 
         if (player.resumeButtons.indexOf(player.lastCom) !== -1) {


### PR DESCRIPTION
## Summary
- add placeholder component constant for special attack bar
- track a player's `specEnergy`
- add opcodes to read and write special energy
- hook special attack button presses to run a script
- add a simple script using the new opcodes

## Testing
- `npx vitest run ./src` *(fails: EHOSTUNREACH)*