### PR TITLE
Add special attack energy cost field

### DIFF
--- a/src/cache/config/ObjType.ts
+++ b/src/cache/config/ObjType.ts
@@ -182,6 +182,7 @@ export default class ObjType extends ConfigType {
     dummyitem = 0;
     tradeable = true;
     respawnrate = 100; // default to 1-minute
+    specialEnergyCost = 0;
     params: ParamMap = new Map();
 
     decode(code: number, dat: Packet): void {
@@ -281,6 +282,8 @@ export default class ObjType extends ConfigType {
             this.countco[code - 100] = dat.g2();
         } else if (code === 201) {
             this.respawnrate = dat.g2();
+        } else if (code === 202) {
+            this.specialEnergyCost = dat.g1();
         } else if (code === 249) {
             this.params = ParamHelper.decodeParams(dat);
         } else if (code === 250) {

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -203,6 +203,7 @@ export default class Player extends PathingEntity {
         }
         sav.p1(this.gender);
         sav.p2(this.runenergy);
+        sav.p1(this.specialEnergy);
         sav.p4(this.playtime);
 
         for (let i = 0; i < 21; i++) {
@@ -288,6 +289,7 @@ export default class Player extends PathingEntity {
     run: number = 0;
     tempRun: number = 0;
     runenergy: number = 10000;
+    specialEnergy: number = 100;
     lastRunEnergy: number = -1;
     runweight: number = 0;
     playtime: number = 0;

--- a/src/engine/entity/PlayerLoading.ts
+++ b/src/engine/entity/PlayerLoading.ts
@@ -11,7 +11,7 @@ import { fromBase37, toBase37 } from '#/util/JString.js';
 
 export class PlayerLoading {
     public static readonly SAV_MAGIC: number = 0x2004;
-    public static readonly SAV_VERSION: number = 6;
+    public static readonly SAV_VERSION: number = 7;
 
     static verify(sav: Packet) {
         if (sav.g2() !== PlayerLoading.SAV_MAGIC) {
@@ -82,6 +82,9 @@ export class PlayerLoading {
         }
         player.gender = sav.g1();
         player.runenergy = sav.g2();
+        if (version >= 7) {
+            player.specialEnergy = sav.g1();
+        }
         if (version >= 2) {
             // oops playtime overflow
             player.playtime = sav.g4();

--- a/src/plugins/specialAttack.ts
+++ b/src/plugins/specialAttack.ts
@@ -1,0 +1,26 @@
+import InvType from '#/cache/config/InvType.js';
+import ObjType from '#/cache/config/ObjType.js';
+import Player from '#/engine/entity/Player.js';
+
+export function attemptSpecialAttack(player: Player): boolean {
+    const worn = player.getInventory(InvType.WORN);
+    if (!worn) {
+        return false;
+    }
+
+    const weapon = worn.get(ObjType.getWearPosId('righthand'));
+    if (!weapon) {
+        return false;
+    }
+
+    const weaponType = ObjType.get(weapon.id);
+    const cost = weaponType.specialEnergyCost;
+    if (player.specialEnergy < cost) {
+        player.messageGame("You don't have enough special attack energy.");
+        return false;
+    }
+
+    player.specialEnergy -= cost;
+    // TODO: trigger weapon-specific special attack effects
+    return true;
+}

--- a/tools/pack/config/ObjConfig.ts
+++ b/tools/pack/config/ObjConfig.ts
@@ -17,7 +17,7 @@ export function parseObjConfig(key: string, value: string): ConfigValue | null |
     // prettier-ignore
     const numberKeys = [
         '2dzoom', '2dxan', '2dyan', '2dxof', '2dyof', '2dzan',
-        'cost', 'respawnrate'
+        'cost', 'respawnrate', 'special_energy_cost'
     ];
     // prettier-ignore
     const booleanKeys = [
@@ -379,6 +379,9 @@ export function packObjConfigs(configs: Map<string, ConfigLine[]>): { client: Pa
             } else if (key === 'respawnrate') {
                 server.p1(201);
                 server.p2(value as number);
+            } else if (key === 'special_energy_cost') {
+                server.p1(202);
+                server.p1(value as number);
             }
         }
 


### PR DESCRIPTION
## Summary
- extend ObjType with `specialEnergyCost`
- parse new `special_energy_cost` from packs
- save/load new `specialEnergy` player stat
- example special attack helper

## Testing
- `npm test` *(fails: `vitest: not found`)*