### PR TITLE
Add script for fixing script permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 1. Download and extract this repo somewhere on your computer.
 2. Install our [dependencies](#dependencies).
-3. Open the folder you downloaded: **Run the quickstart script and follow the on-screen prompts.** You may disregard any severity warnings you see.
+3. Run `./fix-permissions.sh` to make sure script files are executable.
+4. Open the folder you downloaded: **Run the quickstart script and follow the on-screen prompts.** You may disregard any severity warnings you see.
 
 Once your setup process has completed, wait for it to tell you the world has started before trying to play.
 

--- a/fix-permissions.sh
+++ b/fix-permissions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Set executable permissions on script files after unzipping.
+# This avoids "cannot access" errors when running chmod on non-existent files.
+
+find . -type f \( -name "*.sh" -o -name "mvnw" -o -name "gradlew" \) -exec chmod +x {} +
+
+echo "Executable bits applied"


### PR DESCRIPTION
## Summary
- add `fix-permissions.sh` to set executable bits on shell and wrapper scripts
- mention running the new script in Getting Started instructions

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*