### PR TITLE
Remove duplicate SPECENERGY handlers

### DIFF
--- a/src/engine/script/ScriptOpcode.ts
+++ b/src/engine/script/ScriptOpcode.ts
@@ -208,8 +208,6 @@ export const enum ScriptOpcode {
     WEALTH_LOG, // custom
     WEALTH_EVENT, // custom
     P_RUN, // todo: real command name?
-    SPECENERGY,
-    SET_SPECENERGY,
 
     // Npc ops (2500-2999)
     NPC_ADD = 2500, // official
@@ -657,8 +655,6 @@ export const ScriptOpcodeMap: Map<string, number> = new Map([
     ['WEALTH_LOG', ScriptOpcode.WEALTH_LOG],
     ['WEALTH_EVENT', ScriptOpcode.WEALTH_EVENT],
     ['P_RUN', ScriptOpcode.P_RUN],
-    ['SPECENERGY', ScriptOpcode.SPECENERGY],
-    ['SET_SPECENERGY', ScriptOpcode.SET_SPECENERGY],
     ['NPC_ADD', ScriptOpcode.NPC_ADD],
     ['NPC_ANIM', ScriptOpcode.NPC_ANIM],
     ['NPC_BASESTAT', ScriptOpcode.NPC_BASESTAT],

--- a/src/engine/script/ScriptOpcodePointers.ts
+++ b/src/engine/script/ScriptOpcodePointers.ts
@@ -527,14 +527,6 @@ const ScriptOpcodePointers: {
         require: ['p_active_player'],
         require2: ['p_active_player2']
     },
-    [ScriptOpcode.SPECENERGY]: {
-        require: ['active_player'],
-        require2: ['active_player2']
-    },
-    [ScriptOpcode.SET_SPECENERGY]: {
-        require: ['p_active_player'],
-        require2: ['p_active_player2']
-    },
 
     // Npc ops
     [ScriptOpcode.NPC_ADD]: {


### PR DESCRIPTION
## Summary
- remove duplicate `SPECENERGY`/`SET_SPECENERGY` opcodes
- drop redundant pointer entries

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npm test`
