### PR TITLE
Fix permission and TMPDIR handling for tsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ data/config/login.json
 data/config/friend.json
 
 dump/
+tmp/
 
 node_modules/
 

--- a/fix-permissions.sh
+++ b/fix-permissions.sh
@@ -4,4 +4,9 @@
 
 find . -type f \( -name "*.sh" -o -name "mvnw" -o -name "gradlew" \) -exec chmod +x {} +
 
+# Ensure Node.js helper scripts are executable
+if [ -d node_modules/.bin ]; then
+    find node_modules/.bin -type f -exec chmod +x {} +
+fi
+
 echo "Executable bits applied"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 npm i
+sh fix-permissions.sh
 npm run setup
+mkdir -p tmp
+export TMPDIR="$(pwd)/tmp"
 npm run quickstart


### PR DESCRIPTION
## Summary
- ensure Node.js helper scripts in `node_modules/.bin` get executable permissions
- update `quickstart.sh` to set TMPDIR and fix permissions during setup
- ignore the new `tmp/` folder

## Testing
- `npm test`
