### PR TITLE
Update friend limits configuration

### DIFF
--- a/docs/codemap.json
+++ b/docs/codemap.json
@@ -1,0 +1,23 @@
+{
+  "src/util/Environment.ts": {
+    "description": "Environment variable parsing utilities",
+    "exports": [],
+    "depends_on": ["src/util/TryParse.js"],
+    "last_updated": "2025-06-07T03:11:53Z",
+    "commit": "0ec91fd6447c6d54d36476c899f544db05d2853a"
+  },
+  "src/server/friend/FriendServer.ts": {
+    "description": "WebSocket based friend server handling friend interactions",
+    "exports": ["FriendServer"],
+    "depends_on": ["src/util/Environment.ts", "src/server/friend/FriendServerRepository.ts"],
+    "last_updated": "2025-06-07T03:11:53Z",
+    "commit": "0ec91fd6447c6d54d36476c899f544db05d2853a"
+  },
+  "src/server/friend/FriendServerRepository.ts": {
+    "description": "Data store for friends server",
+    "exports": ["FriendServerRepository"],
+    "depends_on": ["src/db/query.js", "src/util/Environment.ts"],
+    "last_updated": "2025-06-07T03:11:53Z",
+    "commit": "0ec91fd6447c6d54d36476c899f544db05d2853a"
+  }
+}

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,10 @@
+[2025-06-07T03:11:53Z]
+Issue: add friend/ignore limits and configuration | File: src/server/friend/FriendServerRepository.ts:208
+Fix: enforce configurable limits via Environment
+Tests: npm test | Result: PASSED
+Rebase: origin/main | Conflicts: none (no remote)
+[2025-06-07T03:13:05Z]
+Issue: update codemap with commit hash | File: docs/codemap.json:1
+Fix: record commit id for last update
+Tests: npm test | Result: PASSED
+Rebase: origin/main | Conflicts: none (no remote)

--- a/src/server/friend/FriendServer.ts
+++ b/src/server/friend/FriendServer.ts
@@ -53,8 +53,8 @@ export const enum FriendsServerOpcodes {
     RELAY_QUEUESCRIPT,
 }
 
-// TODO make this configurable (or at least source it from somewhere common)
-const WORLD_PLAYER_LIMIT = 2000;
+// Configurable world player limit
+const WORLD_PLAYER_LIMIT = Environment.FRIEND_WORLD_PLAYER_LIMIT;
 
 /**
  * TODO refactor, this class shares a lot with the other servers

--- a/src/server/friend/FriendServerRepository.ts
+++ b/src/server/friend/FriendServerRepository.ts
@@ -205,6 +205,10 @@ export class FriendServerRepository {
 
         this.playerFriends[username] = this.playerFriends[username] ?? [];
 
+        if (this.playerFriends[username].length >= Environment.FRIEND_LIST_LIMIT) {
+            return;
+        }
+
         if (this.playerFriends[username].includes(targetUsername37)) {
             // console.error(`[Friends]: ${username} tried to add ${targetUsername} to their friend list, but they are already friends`);
             return;
@@ -222,7 +226,6 @@ export class FriendServerRepository {
             return;
         }
 
-        // TODO check player is not over friends limit
 
         await db
             .insertInto('friendlist')
@@ -238,6 +241,10 @@ export class FriendServerRepository {
 
         this.playerIgnores[username] = this.playerIgnores[username] ?? [];
 
+        if (this.playerIgnores[username].length >= Environment.IGNORE_LIST_LIMIT) {
+            return;
+        }
+
         if (this.playerIgnores[username].includes(value37)) {
             return;
         }
@@ -252,7 +259,6 @@ export class FriendServerRepository {
 
         const { id } = account;
 
-        // TODO check player is not over ignore limit
 
         let query = db.insertInto('ignorelist').values({
             account_id: id,

--- a/src/util/Environment.ts
+++ b/src/util/Environment.ts
@@ -69,6 +69,9 @@ export default {
     FRIEND_SERVER: tryParseBoolean(process.env.FRIEND_SERVER, false),
     FRIEND_HOST: tryParseString(process.env.FRIEND_HOST, 'localhost'),
     FRIEND_PORT: tryParseInt(process.env.FRIEND_PORT, 45099),
+    FRIEND_WORLD_PLAYER_LIMIT: tryParseInt(process.env.FRIEND_WORLD_PLAYER_LIMIT, 2000),
+    FRIEND_LIST_LIMIT: tryParseInt(process.env.FRIEND_LIST_LIMIT, 100),
+    IGNORE_LIST_LIMIT: tryParseInt(process.env.IGNORE_LIST_LIMIT, 100),
 
     /// logger server
     LOGGER_SERVER: tryParseBoolean(process.env.LOGGER_SERVER, false),


### PR DESCRIPTION
## Summary
- make friend world limit configurable
- enforce friend & ignore list size via new environment variables
- track commit hashes in `docs/codemap.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843acec50788326895259ece691dffe