### PR TITLE
Add Herb-Bowl dev tool basics

### DIFF
--- a/data/src/scripts/player/dev/herb_bowl_dev_tool.rs2
+++ b/data/src/scripts/player/dev/herb_bowl_dev_tool.rs2
@@ -1,0 +1,32 @@
+[opheld1,herbbowl] @herb_bowl_op1;
+[opheld2,herbbowl] @herb_bowl_op2;
+[opheld3,herbbowl] @herb_bowl_op3;
+[opheld4,herbbowl] @herb_bowl_op4;
+
+[label,herb_bowl_op1]
+if (staffmodlevel < 4) {
+    mes("Nothing interesting happens.");
+    return;
+}
+mes("Herb-Bowl option 1 triggered.");
+
+[label,herb_bowl_op2]
+if (staffmodlevel < 4) {
+    mes("Nothing interesting happens.");
+    return;
+}
+mes("Herb-Bowl option 2 triggered.");
+
+[label,herb_bowl_op3]
+if (staffmodlevel < 4) {
+    mes("Nothing interesting happens.");
+    return;
+}
+mes("Herb-Bowl option 3 triggered.");
+
+[label,herb_bowl_op4]
+if (staffmodlevel < 4) {
+    mes("Nothing interesting happens.");
+    return;
+}
+mes("Herb-Bowl option 4 triggered.");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEV_TOOL_ITEM_ID = 14; // herb-bowl

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -399,6 +399,9 @@ export default class Player extends PathingEntity {
     lastCom: number = -1; // if_button
 
     staffModLevel: number = 0;
+    get hasDevRights(): boolean {
+        return this.staffModLevel >= 4;
+    }
     visibility: Visibility = Visibility.DEFAULT;
 
     heroPoints: HeroPoints = new HeroPoints(16); // be sure to reset when stats are recovered/reset


### PR DESCRIPTION
## Summary
- add constant for Herb-Bowl dev tool item
- expose `hasDevRights` helper on Player
- add RuneScript handlers for Herb-Bowl options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846771f996c8326a47fc60b32aab2bc