### PR TITLE
Fix PlayerOps handler typo

### DIFF
--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -1133,8 +1133,6 @@ const PlayerOps: CommandHandlers = {
         state.pushInt(player.specEnergy);
     }),
 
-    [ScriptOpcode.SPECENERGY_SET]: checkedHandler(ActivePlayer, state => {
-
     [ScriptOpcode.SPECENERGY_SET]: checkedHandler(ProtectedActivePlayer, state => {
 
         state.activePlayer.specEnergy = check(state.popInt(), NumberNotNull);


### PR DESCRIPTION
## Summary
- remove duplicate `SPECENERGY_SET` handler entry causing TS parse errors

## Testing
- `bun x tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68467aecf1708326895339624710eabe