### PR TITLE
Fix TypeScript dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sort-package-json": "^2.12.0",
     "tinybench": "^3.1.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "5.8.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^3.2.3"
   }


### PR DESCRIPTION
## Summary
- pin `typescript` to `5.8.3` so newer releases won't clash with `typescript-eslint`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476f731ffc8326a2fbb63e055da2c4