### PR TITLE
Update Thieving config names to match in-game terms

### DIFF
--- a/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
+++ b/data/src/scripts/skill_thieving/configs/chests/trapped_chest.dbrow
@@ -1,4 +1,4 @@
-[trapped_chest_chest_10_coins]
+[ardougne_pub_10_coin_chest]
 table=trapped_chest
 data=loc,chest_10_coins
 data=level,13
@@ -6,7 +6,7 @@ data=experience,78
 data=respawn_ticks,15
 data=loot,coins,10,10,128
 
-[trapped_chest_chest_nature_rune]
+[ardougne_pub_nature_rune_chest]
 table=trapped_chest
 data=loc,chest_nature_rune
 data=level,28
@@ -15,7 +15,7 @@ data=respawn_ticks,30
 data=loot,naturerune,1,1,128
 data=loot,coins,3,3,128
 
-[trapped_chest_chest_50_coins]
+[ardougne_pub_upstairs_50_coin_chest]
 table=trapped_chest
 data=loc,chest_50_coins
 data=level,43
@@ -23,7 +23,7 @@ data=experience,1250
 data=respawn_ticks,150
 data=loot,coins,50,50,128
 
-[trapped_chest_chest_steel_arrowtips]
+[rogues_castle_arrowtips_chest]
 table=trapped_chest
 data=loc,chest_steel_arrowtips
 data=level,47
@@ -32,7 +32,7 @@ data=respawn_ticks,250
 data=loot,steel_arrowheads,5,5,128
 data=loot,coins,20,20,128
 
-[trapped_chest_chest_blood_runes]
+[chaos_druid_tower_blood_rune_chest]
 table=trapped_chest
 data=loc,chest_blood_runes
 data=level,59
@@ -42,7 +42,7 @@ data=loot,bloodrune,2,2,128
 data=loot,coins,500,500,128
 data=tele_coord,0_40_52_24_9
 
-[trapped_chest_chest_ardougne_castle]
+[ardougne_castle_paladin_chest]
 table=trapped_chest
 data=loc,chest_ardougne_castle
 data=level,72

--- a/data/src/scripts/skill_thieving/configs/doors/locked_door.dbrow
+++ b/data/src/scripts/skill_thieving/configs/doors/locked_door.dbrow
@@ -1,18 +1,18 @@
-[locked_door_loc_2550]
+[tutorial_hut_door]
 table=locked_door
 data=loc,loc_2550
 data=replacement,loc_2055
 data=level,1
 data=experience,38
 
-[locked_door_loc_2551]
+[varrock_sewers_door]
 table=locked_door
 data=loc,loc_2551
 data=replacement,loc_2055
 data=level,16
 data=experience,150
 
-[locked_door_east_ardy_sewer_gate_north]
+[east_ardougne_sewer_gate_north]
 table=locked_door
 data=loc,east_ardy_sewer_gate_north
 data=replacement,loc_1562
@@ -21,7 +21,7 @@ data=experience,250
 data=mirror,true
 data=gate,true
 
-[locked_door_east_ardy_sewer_gate_south]
+[east_ardougne_sewer_gate_south]
 table=locked_door
 data=loc,east_ardy_sewer_gate_south
 data=replacement,loc_1563
@@ -29,28 +29,28 @@ data=level,31
 data=experience,250
 data=gate,true
 
-[locked_door_loc_2554]
+[desert_palace_treasure_room_door]
 table=locked_door
 data=loc,loc_2554
 data=replacement,loc_2055
 data=level,46
 data=experience,375
 
-[locked_door_loc_2555]
+[legends_guild_gatehouse_rear_door]
 table=locked_door
 data=loc,loc_2555
 data=replacement,loc_2001
 data=level,61
 data=experience,500
 
-[locked_door_loc_2556]
+[draynor_manor_kitchen_side_door]
 table=locked_door
 data=loc,loc_2556
 data=replacement,loc_2001
 data=level,13
 data=experience,150
 
-[locked_door_loc_2557]
+[witchaven_fish_shop_back_door]
 table=locked_door
 data=loc,loc_2557
 data=replacement,loc_1541
@@ -58,7 +58,7 @@ data=level,23
 data=experience,250
 data=tool,lockpick,lockpick
 
-[locked_door_loc_2558]
+[yanille_wizards_guild_side_entrance]
 table=locked_door
 data=loc,loc_2558
 data=replacement,loc_2055
@@ -67,7 +67,7 @@ data=experience,350
 data=tool,lockpick,lockpick
 data=lock_inversed,true
 
-[locked_door_loc_2559]
+[lava_maze_gate]
 table=locked_door
 data=loc,loc_2559
 data=replacement,loc_2070

--- a/data/src/scripts/skill_thieving/configs/pickpocking/pickpocket.dbrow
+++ b/data/src/scripts/skill_thieving/configs/pickpocking/pickpocket.dbrow
@@ -1,4 +1,4 @@
-[pickpocket_man]
+[man]
 table=pickpocket
 data=npc,man
 data=npc,man2
@@ -11,9 +11,9 @@ data=stun_ticks,13
 data=stun_damage,1
 data=success_chance,180,240
 data=loot,coins,3,3,128
-data=pocket,man's pocket
+data=pocket,Man
 
-[pickpocket_woman]
+[woman]
 table=pickpocket
 data=npc,woman
 data=npc,woman2
@@ -25,9 +25,9 @@ data=stun_ticks,13
 data=stun_damage,1
 data=success_chance,180,240
 data=loot,coins,3,3,128
-data=pocket,woman's pocket
+data=pocket,Woman
 
-[pickpocket_farmer]
+[farmer]
 table=pickpocket
 data=npc,farmer
 data=level,10
@@ -36,9 +36,9 @@ data=stun_ticks,13
 data=stun_damage,1
 data=success_chance,150,240
 data=loot,coins,9,9,123
-data=pocket,farmer's pocket
+data=pocket,Farmer
 
-[pickpocket_warrior]
+[warrior_woman]
 table=pickpocket
 data=npc,warrior_woman
 data=npc,al_kharid_warrior
@@ -48,9 +48,9 @@ data=stun_ticks,13
 data=stun_damage,2
 data=success_chance,100,240
 data=loot,coins,18,18,128
-data=pocket,warrior's pocket
+data=pocket,Warrior Woman / Al-Kharid Warrior
 
-[pickpocket_rogue]
+[rogue]
 table=pickpocket
 data=npc,rogue
 data=level,32
@@ -63,9 +63,9 @@ data=loot,airrune,8,8,8
 data=loot,jug_wine,1,1,6
 data=loot,lockpick,1,1,5
 data=loot,iron_dagger_p,1,1,1
-data=pocket,rogue's pocket
+data=pocket,Rogue
 
-[pickpocket_guard]
+[guard]
 table=pickpocket
 data=npc,guard1
 data=npc,guard2
@@ -76,9 +76,9 @@ data=stun_ticks,13
 data=stun_damage,2
 data=success_chance,50,240
 data=loot,coins,30,30,128
-data=pocket,guard's pocket
+data=pocket,Guard
 
-[pickpocket_knight_of_ardougne]
+[knight_of_ardougne]
 table=pickpocket
 data=npc,knight_of_ardougne
 data=npc,knight_of_ardougne2
@@ -88,9 +88,9 @@ data=stun_ticks,13
 data=stun_damage,3
 data=success_chance,50,240
 data=loot,coins,50,50,128
-data=pocket,knight's pocket
+data=pocket,Knight of Ardougne
 
-[pickpocket_watchman]
+[watchman]
 table=pickpocket
 data=npc,yanille_watchman
 data=level,65
@@ -100,9 +100,9 @@ data=stun_damage,3
 data=success_chance,15,160
 data=loot,coins,60,60,128
 data=loot,bread,1,1,128
-data=pocket,watchman's pocket
+data=pocket,Watchman
 
-[pickpocket_paladin]
+[paladin]
 table=pickpocket
 data=npc,paladin
 data=level,70
@@ -112,9 +112,9 @@ data=stun_damage,3
 data=success_chance,50,150
 data=loot,coins,80,80,128
 data=loot,chaosrune,2,2,128
-data=pocket,paladin's pocket
+data=pocket,Paladin
 
-[pickpocket_gnome]
+[gnome]
 table=pickpocket
 data=npc,gnome
 data=npc,browclothedgnome
@@ -135,9 +135,9 @@ data=loot,swamp_toad,1,1,28
 data=loot,gold_ore,1,1,8
 data=loot,earthrune,1,1,5
 data=loot,fire_orb,1,1,2
-data=pocket,gnome's pocket
+data=pocket,Gnome
 
-[pickpocket_hero]
+[hero]
 table=pickpocket
 data=npc,hero
 data=level,80
@@ -152,4 +152,4 @@ data=loot,bloodrune,1,1,5
 data=loot,fire_orb,1,1,2
 data=loot,diamond,1,1,1
 data=loot,gold_ore,1,1,1
-data=pocket,hero's pocket
+data=pocket,Hero

--- a/data/src/scripts/skill_thieving/configs/stalls/stealing.dbrow
+++ b/data/src/scripts/skill_thieving/configs/stalls/stealing.dbrow
@@ -11,7 +11,7 @@ data=loot,cake,1,1,13,a cake
 data=loot,bread,1,1,5,some bread
 data=loot,chocolate_slice,1,1,2,a chocolate slice
 data=loot_total,20
-data=stall,baker's stall
+data=stall,Bakery stall
 
 [stealing_tea_stall]
 table=stealing
@@ -23,7 +23,7 @@ data=experience,160
 data=respawn_ticks,16
 data=loot,cup_of_tea,1,1,128,a cup of tea
 data=loot_total,128
-data=stall,tea stall
+data=stall,Tea stall
 data=stall,a cup of tea
 
 [stealing_silk_stall]
@@ -39,7 +39,7 @@ data=experience,240
 data=respawn_ticks,16
 data=loot,silk,1,1,128,a piece of silk
 data=loot_total,128
-data=stall,silk stall
+data=stall,Silk stall
 data=stall,some silk
 
 [stealing_fur_stall]
@@ -54,7 +54,7 @@ data=experience,360
 data=respawn_ticks,32
 data=loot,grey_wolf_fur,1,1,128,a piece of fur
 data=loot_total,128
-data=stall,fur stall
+data=stall,Fur stall
 data=stall,some fur
 
 [stealing_silver_stall]
@@ -71,7 +71,7 @@ data=experience,540
 data=respawn_ticks,100
 data=loot,silver_ore,1,1,128,some silver
 data=loot_total,128
-data=stall,silver stall
+data=stall,Silver stall
 data=stall,some silver
 
 [stealing_spice_stall]
@@ -88,7 +88,7 @@ data=experience,810
 data=respawn_ticks,166
 data=loot,spicespot,1,1,128,some spice
 data=loot_total,128
-data=stall,spice stall
+data=stall,Spice stall
 data=stall,some spice
 
 [stealing_gem_stall]
@@ -110,5 +110,5 @@ data=loot,uncut_emerald,1,1,17,an uncut emerald
 data=loot,uncut_ruby,1,1,5,an uncut ruby
 data=loot,uncut_diamond,1,1,1,an uncut diamond
 data=loot_total,128
-data=stall,gem stall
+data=stall,Gem stall
 data=stall,a gem

--- a/docs/THIEVING_LEVELS.md
+++ b/docs/THIEVING_LEVELS.md
@@ -2,20 +2,22 @@
 
 The following table consolidates all thieving-related requirements present in this codebase. These values mirror the May 18, 2004 snapshot.
 
+Config identifiers in the data files have been renamed to match in-game terminology for ease of reference.
+
 ## Pickpocket Targets
 
-| Level | Code ID | NPC Name |
-| ----- | ------- | -------- |
-| 1 | `pickpocket_man` / `pickpocket_woman` | Man / Woman |
-| 10 | `pickpocket_farmer` | Farmer |
-| 25 | `pickpocket_warrior` | Warrior Woman / Al-Kharid Warrior |
-| 32 | `pickpocket_rogue` | Rogue |
-| 40 | `pickpocket_guard` | Guard |
-| 55 | `pickpocket_knight_of_ardougne` | Knight of Ardougne |
-| 65 | `pickpocket_watchman` | Watchman (Yanille) |
-| 70 | `pickpocket_paladin` | Paladin |
-| 75 | `pickpocket_gnome` | Tree-Gnome Stronghold Gnome |
-| 80 | `pickpocket_hero` | Hero |
+| Level | Config ID | NPC Name |
+| ----- | --------- | -------- |
+| 1 | `man` / `woman` | Man / Woman |
+| 10 | `farmer` | Farmer |
+| 25 | `warrior_woman` | Warrior Woman / Al-Kharid Warrior |
+| 32 | `rogue` | Rogue |
+| 40 | `guard` | Guard |
+| 55 | `knight_of_ardougne` | Knight of Ardougne |
+| 65 | `watchman` | Watchman (Yanille) |
+| 70 | `paladin` | Paladin |
+| 75 | `gnome` | Tree-Gnome Stronghold Gnome |
+| 80 | `hero` | Hero |
 
 ## Market Stalls
 
@@ -30,28 +32,28 @@ The following table consolidates all thieving-related requirements present in th
 
 ## Locked Doors and Gates
 
-| Level | Code ID / Location | Details |
-| ----- | ----------------- | ------- |
-| 1 | `loc_2550` | Tutorial hut doors (Karamja) |
-| 13 | `loc_2556` | Draynor Manor kitchen side-door |
-| 16 | `loc_2551` | Varrock Sewers wooden door |
-| 23 | `loc_2557` | Witchaven fish-shop back door |
-| 31 | `east_ardy_sewer_gate_(N/S)` | East Ardougne sewer gates |
-| 39 | `loc_2558` | Yanille Wizards’ Guild side entrance |
-| 46 | `loc_2554` | Desert palace treasure room |
-| 61 | `loc_2555` | Legends’ Guild gatehouse rear door |
-| 82 | `loc_2559` | Deep Wilderness Lava Maze gate |
+| Level | Config ID / Location | Details |
+| ----- | ------------------- | ------- |
+| 1 | `tutorial_hut_door` | Tutorial hut doors (Karamja) |
+| 13 | `draynor_manor_kitchen_side_door` | Draynor Manor kitchen side-door |
+| 16 | `varrock_sewers_door` | Varrock Sewers wooden door |
+| 23 | `witchaven_fish_shop_back_door` | Witchaven fish-shop back door |
+| 31 | `east_ardougne_sewer_gate_north` / `east_ardougne_sewer_gate_south` | East Ardougne sewer gates |
+| 39 | `yanille_wizards_guild_side_entrance` | Yanille Wizards’ Guild side entrance |
+| 46 | `desert_palace_treasure_room_door` | Desert palace treasure room |
+| 61 | `legends_guild_gatehouse_rear_door` | Legends’ Guild gatehouse rear door |
+| 82 | `lava_maze_gate` | Deep Wilderness Lava Maze gate |
 
 ## Trapped and Loot Chests
 
-| Level | Chest | Notable Rewards |
-| ----- | ----- | --------------- |
-| 13 | 10-coin chest – Ardougne pub | 10 gp |
-| 28 | Nature-rune chest – Ardougne pub | 1 nature rune + 3 gp |
-| 43 | 50-coin chest – upstairs Ardougne pub | 50 gp |
-| 47 | Steel arrowtips chest – Rogue’s Castle | 6 arrowtips |
-| 59 | Blood-rune chest – Chaos Druid tower | 2 blood runes + 500 gp |
-| 72 | Paladin chests – Ardougne Castle | 1,000 gp / raw sharks (teleports to Witchaven on fail) |
+| Level | Config ID | Notable Rewards |
+| ----- | --------- | --------------- |
+| 13 | `ardougne_pub_10_coin_chest` | 10 gp |
+| 28 | `ardougne_pub_nature_rune_chest` | 1 nature rune + 3 gp |
+| 43 | `ardougne_pub_upstairs_50_coin_chest` | 50 gp |
+| 47 | `rogues_castle_arrowtips_chest` | 6 arrowtips |
+| 59 | `chaos_druid_tower_blood_rune_chest` | 2 blood runes + 500 gp |
+| 72 | `ardougne_castle_paladin_chest` | 1,000 gp / raw sharks (teleports to Witchaven on fail) |
 
 ## Quest-Level Checks
 


### PR DESCRIPTION
## Summary
- rename pickpocket configs and descriptions to use NPC names
- rename locked door and chest config labels
- capitalize stall names in stealing config
- document new naming scheme for thieving configs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fba22fa8c8326a1be61cbd06e7a73